### PR TITLE
feat(config)!: Implement default for all config structs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // Basic auth configuration
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct BasicAuth {
     pub enabled: bool,
     pub username: String,
@@ -10,7 +10,7 @@ pub struct BasicAuth {
 }
 
 // Configuration for metrics
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct MetricsConfig {
     pub enabled: bool,
     pub endpoint: String,
@@ -18,7 +18,7 @@ pub struct MetricsConfig {
 }
 
 // Configuration for logs
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct LogsConfig {
     pub enabled: bool,
     pub endpoint: String,
@@ -26,7 +26,7 @@ pub struct LogsConfig {
 }
 
 // Configuration for traces
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct TracesConfig {
     pub enabled: bool,
     pub endpoint: String,
@@ -34,7 +34,7 @@ pub struct TracesConfig {
 }
 
 // Configuration for profiles
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct ProfilesConfig {
     pub enabled: bool,
     pub endpoint: String,
@@ -42,61 +42,17 @@ pub struct ProfilesConfig {
 }
 
 // Global labels to be added to all telemetry types
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct TelemetryLabels {
     pub labels: HashMap<String, String>,
 }
 
 // Configuration for telemetry components
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct TelemetryConfig {
     pub metrics: MetricsConfig,
     pub logs: LogsConfig,
     pub traces: TracesConfig,
     pub profiles: ProfilesConfig,
     pub global_labels: TelemetryLabels,
-}
-
-pub fn get_default_telemetry_config() -> TelemetryConfig {
-    TelemetryConfig {
-        metrics: MetricsConfig {
-            enabled: false,
-            endpoint: "".to_string(),
-            auth: BasicAuth {
-                enabled: false,
-                username: "".to_string(),
-                password: "".to_string(),
-            },
-        },
-        logs: LogsConfig {
-            enabled: false,
-            endpoint: "".to_string(),
-            auth: BasicAuth {
-                enabled: false,
-                username: "".to_string(),
-                password: "".to_string(),
-            },
-        },
-        traces: TracesConfig {
-            enabled: false,
-            endpoint: "".to_string(),
-            auth: BasicAuth {
-                enabled: false,
-                username: "".to_string(),
-                password: "".to_string(),
-            },
-        },
-        profiles: ProfilesConfig {
-            enabled: false,
-            endpoint: "".to_string(),
-            auth: BasicAuth {
-                enabled: false,
-                username: "".to_string(),
-                password: "".to_string(),
-            },
-        },
-        global_labels: TelemetryLabels {
-            labels: HashMap::new(),
-        },
-    }
 }


### PR DESCRIPTION
Enables external configs that embed TelemetryConfig, to derive Default without custom code.

**BREAKING CHANGE**: `get_default_telemetry_config()` is not available any more. It is replaced by using `TelemetryConfig::default()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved configuration handling to allow default values for all telemetry-related settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->